### PR TITLE
Tensorboard tag: Must capitalize the L in "Policy Loss"

### DIFF
--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -228,7 +228,7 @@ class TFProcess:
             sum_mse /= (4.0 * test_batches)
             test_summaries = tf.Summary(value=[
                 tf.Summary.Value(tag="Accuracy", simple_value=sum_accuracy),
-                tf.Summary.Value(tag="Policy loss", simple_value=sum_policy),
+                tf.Summary.Value(tag="Policy Loss", simple_value=sum_policy),
                 tf.Summary.Value(tag="MSE Loss", simple_value=sum_mse)])
             self.test_writer.add_summary(test_summaries, steps)
             print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\


### PR DESCRIPTION
With the wrong capitalization, Tensorboard outputs the "Policy loss" (lowercase L) onto a different scalar chart than "Policy Loss". Instead, the policy loss logs for both test and train should be output onto the same chart, as is already the case for the Tensorboard MSE Loss chart.